### PR TITLE
docs: 📝 add eslint code editor instructions

### DIFF
--- a/packages/u/README.md
+++ b/packages/u/README.md
@@ -40,6 +40,18 @@ You can also run scripts directly. Each script is run with preconfigured default
 | `u jest`     | Runs [jest](https://jestjs.io/en/). Customize with `jest.config.js`.        |
 | `u prettier` | Runs [prettier](https://prettier.io/). Customize with `prettier.config.js`. |
 
+### Eslint in your code editor
+
+You can direct your code editor to use u script eslint rules by extending eslintConfig in your projects package.json
+
+```
+{
+  "eslintConfig": {
+    "extends": "@jr.codes"
+  }
+}
+```
+
 ## 🌱 Inspiration
 
 - [Create React App](https://github.com/facebook/create-react-app)


### PR DESCRIPTION
Adds information on how to get u scripts eslint rules working and displaying in your code editor (e.g. VS Code + Eslint Extension)